### PR TITLE
Prevent caching response in GETs using JWT header

### DIFF
--- a/jwt.services.yml
+++ b/jwt.services.yml
@@ -4,6 +4,11 @@ services:
     arguments: [ '@entity_type.manager', '@jwt.validator', '@event_dispatcher' ]
     tags:
       - { name: authentication_provider, provider_id: 'jwt_auth', global: TRUE, priority: 100 }
+  jwt.page_cache_request_policy.disallow_jwt_auth_requests:
+      class: Drupal\jwt\PageCache\DisallowJwtAuthRequests
+      public: false
+      tags:
+        - { name: page_cache_request_policy }
   jwt.firebase.php-jwt:
     class: Firebase\JWT\JWT
   jwt.validator:

--- a/src/PageCache/DisallowJwtAuthRequests.php
+++ b/src/PageCache/DisallowJwtAuthRequests.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\jwt\PageCache;
+
+use Drupal\Core\PageCache\RequestPolicyInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Cache policy for pages served from JWT auth.
+ *
+ * This policy disallows caching of requests that use jwt_auth for security
+ * reasons. Otherwise responses for authenticated requests can get into the
+ * page cache and could be delivered to unprivileged users.
+ */
+class DisallowJwtAuthRequests implements RequestPolicyInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function check(Request $request) {
+    $auth = $request->headers->get('Authorization');
+    if(preg_match('/^Bearer .+/', $auth)) {
+      return self::DENY;
+    }
+  }
+
+}


### PR DESCRIPTION
Implement Drupal RequestPolicyInterface to prevent get responses from
being cached when using jwt_auth. Before making a get request would
cache and another request without the token would be served up the same
content.

Fixes issue 2791127:
https://www.drupal.org/node/2791127