### PR TITLE
Big drupal coding standards cleanup

### DIFF
--- a/modules/jwt_auth_consumer/src/EventSubscriber/JwtAuthConsumerSubscriber.php
+++ b/modules/jwt_auth_consumer/src/EventSubscriber/JwtAuthConsumerSubscriber.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_consumer\JwtAuthConsumerSubscriber.
- */
-
 namespace Drupal\jwt_auth_consumer\EventSubscriber;
 
 use Drupal\jwt\Authentication\Provider\JwtAuthEvent;
@@ -39,7 +34,7 @@ class JwtAuthConsumerSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  static function getSubscribedEvents() {
+  public static function getSubscribedEvents() {
     $events[JwtAuthEvents::VALIDATE][] = array('validate');
     $events[JwtAuthEvents::VALID][] = array('loadUser');
 
@@ -53,7 +48,7 @@ class JwtAuthConsumerSubscriber implements EventSubscriberInterface {
    * valid uid in the system.
    *
    * @param \Drupal\jwt\Authentication\Provider\JwtAuthEvent $event
-   *  A JwtAuth event.
+   *   A JwtAuth event.
    */
   public function validate(JwtAuthEvent $event) {
     $token = $event->getToken();
@@ -66,7 +61,7 @@ class JwtAuthConsumerSubscriber implements EventSubscriberInterface {
    * Load and set a Drupal user to be authentication based on the JWT's uid.
    *
    * @param \Drupal\jwt\Authentication\Provider\JwtAuthEvent $event
-   *  A JwtAuth event.
+   *   A JwtAuth event.
    */
   public function loadUser(JwtAuthEvent $event) {
     $token = $event->getToken();

--- a/modules/jwt_auth_issuer/Tests/Controller/JwtAuthIssuerControllerTest.php
+++ b/modules/jwt_auth_issuer/Tests/Controller/JwtAuthIssuerControllerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_issuer\Tests\JwtAuthIssuerController.
- */
-
 namespace Drupal\jwt_auth_issuer\Tests;
 
 use Drupal\simpletest\WebTestBase;
@@ -14,12 +9,6 @@ use Drupal\simpletest\WebTestBase;
  */
 class JwtAuthIssuerControllerTest extends WebTestBase {
 
-  /**
-   * Firebase\JWT\JWT definition.
-   *
-   * @var \Firebase\JWT\JWT
-   */
-  protected $jwt_firebase_php_jwt;
   /**
    * {@inheritdoc}
    */

--- a/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerController.php
+++ b/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerController.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_issuer\Controller\JwtAuthIssuerController.
- */
-
 namespace Drupal\jwt_auth_issuer\Controller;
 
 use Drupal\jwt\JsonWebToken\JsonWebToken;
@@ -55,11 +50,11 @@ class JwtAuthIssuerController extends ControllerBase {
   /**
    * {@inheritdoc}
    *
-   * @param \Drupal\jwt\Transcoder\JwtTranscoderInterface
-   *  The JWT transcoder service.
+   * @param \Drupal\jwt\Transcoder\JwtTranscoderInterface $transcoder
+   *   The JWT transcoder service.
    * @param string $secret
    *   The secret to be used for the JWT.
-   * @param \Drupal\key\KeyRepositoryInterface $keyRepo
+   * @param \Drupal\key\KeyRepositoryInterface $key_repo
    *   The key module repository service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher service.
@@ -99,7 +94,7 @@ class JwtAuthIssuerController extends ControllerBase {
   public function tokenResponse() {
     $response = new \stdClass();
 
-    if($this->secret === NULL) {
+    if ($this->secret === NULL) {
       $response->error = "Please set a key in the JWT admin page.";
       return new JsonResponse($response, 500);
     }

--- a/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerEvent.php
+++ b/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerEvent.php
@@ -1,14 +1,14 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_issuer\Controller\JwtAuthIssuerEvent.
- */
-
 namespace Drupal\jwt_auth_issuer\Controller;
 
 use Drupal\jwt\Authentication\Provider\JwtAuthEvent;
 
+/**
+ * Class JwtAuthIssuerEvent.
+ *
+ * @package Drupal\jwt_auth_issuer\Controller
+ */
 class JwtAuthIssuerEvent extends JwtAuthEvent {
 
   /**

--- a/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerEvents.php
+++ b/modules/jwt_auth_issuer/src/Controller/JwtAuthIssuerEvents.php
@@ -1,12 +1,12 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_issuer\Controller\JwtAuthIssuerEvents.
- */
-
 namespace Drupal\jwt_auth_issuer\Controller;
 
+/**
+ * Class JwtAuthIssuerEvents.
+ *
+ * @package Drupal\jwt_auth_issuer\Controller
+ */
 final class JwtAuthIssuerEvents {
 
   /**

--- a/modules/jwt_auth_issuer/src/EventSubscriber/JwtAuthIssuerSubscriber.php
+++ b/modules/jwt_auth_issuer/src/EventSubscriber/JwtAuthIssuerSubscriber.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt_auth_issuer\JwtAuthIssuerSubscriber.
- */
-
 namespace Drupal\jwt_auth_issuer\EventSubscriber;
 
 use Drupal\Core\Session\AccountInterface;
@@ -31,7 +26,7 @@ class JwtAuthIssuerSubscriber implements EventSubscriberInterface {
    * Constructor.
    *
    * @param \Drupal\Core\Session\AccountInterface $user
-   *  The current user.
+   *   The current user.
    */
   public function __construct(AccountInterface $user) {
     $this->currentUser = $user;
@@ -40,7 +35,7 @@ class JwtAuthIssuerSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  static function getSubscribedEvents() {
+  public static function getSubscribedEvents() {
     $events[JwtAuthIssuerEvents::GENERATE][] = array('setStandardClaims', 100);
     $events[JwtAuthIssuerEvents::GENERATE][] = array('setDrupalClaims', 99);
     return $events;
@@ -50,6 +45,7 @@ class JwtAuthIssuerSubscriber implements EventSubscriberInterface {
    * Sets the standard claims set for a JWT.
    *
    * @param \Drupal\jwt_auth_issuer\Controller\JwtAuthIssuerEvent $event
+   *   The event.
    */
   public function setStandardClaims(JwtAuthIssuerEvent $event) {
     $event->addClaim('iat', time());
@@ -61,12 +57,13 @@ class JwtAuthIssuerSubscriber implements EventSubscriberInterface {
    * Sets claims for a Drupal consumer on the JWT.
    *
    * @param \Drupal\jwt_auth_issuer\Controller\JwtAuthIssuerEvent $event
+   *   The event.
    */
   public function setDrupalClaims(JwtAuthIssuerEvent $event) {
     $event->addClaim(
       array(
         0 => 'drupal',
-        1 => 'uid'
+        1 => 'uid',
       ),
       $this->currentUser->id()
     );

--- a/src/Authentication/Provider/JwtAuth.php
+++ b/src/Authentication/Provider/JwtAuth.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Authentication\Provider\JwtAuth.
- */
-
 namespace Drupal\jwt\Authentication\Provider;
 
 use Drupal\jwt\JsonWebToken\JsonWebTokenInterface;
@@ -47,7 +42,7 @@ class JwtAuth implements AuthenticationProviderInterface {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The user authentication service.
-   * @param \Drupal\jwt\JwtValidatorInterface
+   * @param \Drupal\jwt\Validator\JwtValidatorInterface $validator
    *   The jwt validator service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher service.
@@ -72,7 +67,8 @@ class JwtAuth implements AuthenticationProviderInterface {
   public function authenticate(Request $request) {
     try {
       $jwt = $this->validator->getJwt();
-    } catch (JwtInvalidException $e) {
+    }
+    catch (JwtInvalidException $e) {
       throw new AccessDeniedHttpException($e->getMessage(), $e);
     }
 
@@ -87,13 +83,15 @@ class JwtAuth implements AuthenticationProviderInterface {
    * Allow the system to interpret token and provide a user id.
    *
    * @param \Drupal\jwt\JsonWebToken\JsonWebTokenInterface $jwt
+   *   The token to get the user from.
    *
-   * @return mixed $uid
-   *  A loaded user object.
+   * @return mixed
+   *   A loaded user object.
    */
   private function getUser(JsonWebTokenInterface $jwt) {
     $event = new JwtAuthEvent($jwt);
     $this->eventDispatcher->dispatch(JwtAuthEvents::VALID, $event);
     return $event->getUser();
   }
+
 }

--- a/src/Authentication/Provider/JwtAuthEvent.php
+++ b/src/Authentication/Provider/JwtAuthEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Authentication\Provider\JwtAuthEvent.
- */
-
 namespace Drupal\jwt\Authentication\Provider;
 
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 use Symfony\Component\EventDispatcher\Event;
+use Drupal\jwt\JsonWebToken\JsonWebTokenInterface;
 
+/**
+ * Class JwtAuthEvent.
+ *
+ * @package Drupal\jwt\Authentication\Provider
+ */
 class JwtAuthEvent extends Event {
   /**
    * Variable holding the user authenticated by the token in the payload.
@@ -43,10 +44,10 @@ class JwtAuthEvent extends Event {
   /**
    * Constructs a JwtAuthEvent with a JsonWebToken.
    *
-   * @param $token
-   *  A decoded JWT.
+   * @param \Drupal\jwt\JsonWebToken\JsonWebTokenInterface $token
+   *   A decoded JWT.
    */
-  public function __construct($token) {
+  public function __construct(JsonWebTokenInterface $token) {
     $this->jwt = $token;
     $this->user = User::getAnonymousUser();
   }
@@ -55,16 +56,17 @@ class JwtAuthEvent extends Event {
    * Sets the authenticated user that will be used for this request.
    *
    * @param \Drupal\user\UserInterface $user
-   *  A loaded user object.
-   */ public function setUser(UserInterface $user) {
+   *   A loaded user object.
+   */
+  public function setUser(UserInterface $user) {
     $this->user = $user;
   }
 
   /**
    * Returns a loaded user to use if the token is validated.
    *
-   * @return \Drupal\user\UserInterface $user
-   *  A loaded user object
+   * @return \Drupal\user\UserInterface
+   *   A loaded user object
    */
   public function getUser() {
     return $this->user;
@@ -74,20 +76,21 @@ class JwtAuthEvent extends Event {
    * Returns the JWT.
    *
    * @return \Drupal\jwt\JsonWebToken\JsonWebTokenInterface
+   *   Returns the token.
    */
   public function getToken() {
     return $this->jwt;
   }
 
   /**
-   * Marks a token as invalid and stops further propogation of the event.
+   * Marks a token as invalid and stops further propagation of the event.
    *
    * This marks a given token as invalid. You should provide a reason for
    * invalidating the token. This message will not be kept private, so one
    * should be cautious of leaking secure information here.
    *
    * @param string $reason
-   *  The reason that this token was invalidated.
+   *   The reason that this token was invalidated.
    */
   public function invalidate($reason) {
     $this->valid = FALSE;
@@ -99,6 +102,7 @@ class JwtAuthEvent extends Event {
    * Returns whether a token was considered valid.
    *
    * @return bool
+   *   Returns if the token is valid.
    */
   public function isValid() {
     return $this->valid;
@@ -107,7 +111,8 @@ class JwtAuthEvent extends Event {
   /**
    * Returns a string describing why a JWT was considered invalid.
    *
-   * @return bool
+   * @return string
+   *   The reason the token is invalid.
    */
   public function invalidReason() {
     return $this->invalidReason;

--- a/src/Authentication/Provider/JwtAuthEvents.php
+++ b/src/Authentication/Provider/JwtAuthEvents.php
@@ -1,19 +1,19 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Authentication\Provider\JwtAuthEvents.
- */
-
 namespace Drupal\jwt\Authentication\Provider;
 
+/**
+ * Class JwtAuthEvents.
+ *
+ * @package Drupal\jwt\Authentication\Provider
+ */
 final class JwtAuthEvents {
 
   /**
    * Name of the event fired before validating a JWT.
    *
    * This event allows modules to provide custom validations for a JWT.
-   * Subscibers should assume every token is invalid. Therefore, this event
+   * Subscribers should assume every token is invalid. Therefore, this event
    * should NOT perform any actions that depend on a valid JWT. This allows
    * other subscribers to invalidate the JWT. Actions that depend on a valid
    * token should use the VALID event.

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\jwt\Form\ConfigForm.
- */
-
 namespace Drupal\jwt\Form;
 
 use Drupal\Core\Form\ConfigFormBase;

--- a/src/JsonWebToken/JsonWebToken.php
+++ b/src/JsonWebToken/JsonWebToken.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\JsonWebToken\JsonWebToken.
- */
-
 namespace Drupal\jwt\JsonWebToken;
 
 /**
@@ -21,7 +16,13 @@ class JsonWebToken implements JsonWebTokenInterface {
    */
   protected $payload;
 
-  public function __construct($jwt = null) {
+  /**
+   * JsonWebToken constructor.
+   *
+   * @param object $jwt
+   *   The Object to turn into a JWT.
+   */
+  public function __construct($jwt = NULL) {
     $jwt = (is_null($jwt)) ? new \stdClass() : $jwt;
     $this->payload = $jwt;
   }
@@ -38,7 +39,7 @@ class JsonWebToken implements JsonWebTokenInterface {
    */
   public function getClaim($claim) {
     $payload = $this->payload;
-    return $this->_getClaim($payload, $claim);
+    return $this->internalGetClaim($payload, $claim);
   }
 
   /**
@@ -46,7 +47,7 @@ class JsonWebToken implements JsonWebTokenInterface {
    */
   public function setClaim($claim, $value) {
     $payload = $this->payload;
-    $this->_setClaim($payload, $claim, $value);
+    $this->internalSetClaim($payload, $claim, $value);
     $this->payload = $payload;
   }
 
@@ -55,7 +56,7 @@ class JsonWebToken implements JsonWebTokenInterface {
    */
   public function unsetClaim($claim) {
     $payload = $this->payload;
-    $this->_unsetClaim($payload, $claim);
+    $this->internalUnsetClaim($payload, $claim);
     $this->payload = $payload;
   }
 
@@ -63,21 +64,23 @@ class JsonWebToken implements JsonWebTokenInterface {
    * Traverses the JWT payload to the given claim and returns its value.
    *
    * @param object $payload
-   *  A reference to the JWT payload.
+   *   A reference to the JWT payload.
    * @param mixed $claim
-   *  Either a string or indexed array of strings representing the claim or
-   *  nested claim to be set.
+   *   Either a string or indexed array of strings representing the claim or
+   *   nested claim to be set.
+   *
    * @return mixed
+   *   The claims value.
    */
-  protected function _getClaim(&$payload, $claim) {
+  protected function internalGetClaim(&$payload, $claim) {
     $current_claim = (is_array($claim)) ? array_shift($claim) : $claim;
 
     if (!isset($payload->$current_claim)) {
-      return null;
+      return NULL;
     }
 
     if (is_array($claim) && count($claim) > 0) {
-      return $this->_getClaim($payload->$current_claim, $claim);
+      return $this->internalGetClaim($payload->$current_claim, $claim);
     }
     else {
       return $payload->$current_claim;
@@ -88,14 +91,14 @@ class JsonWebToken implements JsonWebTokenInterface {
    * Traverses the JWT payload to the given claim and sets a value.
    *
    * @param object $payload
-   *  A reference to the JWT payload.
+   *   A reference to the JWT payload.
    * @param mixed $claim
-   *  Either a string or indexed array of strings representing the claim or
-   *  nested claim to be set.
+   *   Either a string or indexed array of strings representing the claim or
+   *   nested claim to be set.
    * @param mixed $value
-   *  The value to set for the given claim.
+   *   The value to set for the given claim.
    */
-  protected function _setClaim(&$payload, $claim, $value) {
+  protected function internalSetClaim(&$payload, $claim, $value) {
     $current_claim = (is_array($claim)) ? array_shift($claim) : $claim;
 
     if (is_array($claim) && count($claim) > 0) {
@@ -103,7 +106,7 @@ class JsonWebToken implements JsonWebTokenInterface {
         $payload->$current_claim = new \stdClass();
       }
 
-      $this->_setClaim($payload->$current_claim, $claim, $value);
+      $this->internalSetClaim($payload->$current_claim, $claim, $value);
     }
     else {
       $payload->$current_claim = $value;
@@ -111,15 +114,15 @@ class JsonWebToken implements JsonWebTokenInterface {
   }
 
   /**
-   * Traverses the JWT payload to the given claim and unsets its value.
+   * Traverses the JWT payload to the given claim and unset its value.
    *
    * @param object $payload
-   *  A reference to the JWT payload.
+   *   A reference to the JWT payload.
    * @param mixed $claim
-   *  Either a string or indexed array of strings representing the claim or
-   *  nested claim to be set.
+   *   Either a string or indexed array of strings representing the claim or
+   *   nested claim to be set.
    */
-  protected function _unsetClaim(&$payload, $claim) {
+  protected function internalUnsetClaim(&$payload, $claim) {
     $current_claim = (is_array($claim)) ? array_shift($claim) : $claim;
 
     if (!isset($payload->$current_claim)) {
@@ -127,7 +130,7 @@ class JsonWebToken implements JsonWebTokenInterface {
     }
 
     if (is_array($claim) && count($claim) > 0) {
-      $this->_unsetClaim($payload->$current_claim, $claim);
+      $this->internalUnsetClaim($payload->$current_claim, $claim);
     }
     else {
       unset($payload->$current_claim);

--- a/src/JsonWebToken/JsonWebTokenInterface.php
+++ b/src/JsonWebToken/JsonWebTokenInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\JsonWebToken\JsonWebTokenInterface.
- */
-
 namespace Drupal\jwt\JsonWebToken;
 
 /**
@@ -18,6 +13,7 @@ interface JsonWebTokenInterface {
    * Gets the unencoded payload as an object.
    *
    * @return \stdclass
+   *   The unencoded payload.
    */
   public function getPayload();
 
@@ -25,9 +21,10 @@ interface JsonWebTokenInterface {
    * Retrieve a claim from the JWT payload.
    *
    * @param mixed $claim
-   *  Either a string or indexed array of strings (if nested) representing the
-   *  claim to retrieve. If an indexed array is passed, it will be used to
-   *  traverse the JWT where the 0th element is the topmost claim.
+   *   Either a string or indexed array of strings (if nested) representing the
+   *   claim to retrieve. If an indexed array is passed, it will be used to
+   *   traverse the JWT where the 0th element is the topmost claim.
+   *
    * @returns mixed The contents of the claim.
    */
   public function getClaim($claim);
@@ -36,11 +33,10 @@ interface JsonWebTokenInterface {
    * Add or update the given claim with the given value.
    *
    * @param mixed $claim
-   *  Either a string or indexed array of strings representing the claim or
-   *  nested claim to be set.
-   *
+   *   Either a string or indexed array of strings representing the claim or
+   *   nested claim to be set.
    * @param mixed $value
-   *  A serializable value to set the given claim to on the JWT.
+   *   A serializable value to set the given claim to on the JWT.
    */
   public function setClaim($claim, $value);
 
@@ -48,7 +44,7 @@ interface JsonWebTokenInterface {
    * Remove a claim from the JWT payload.
    *
    * @param mixed $claim
-   *  Either a string or indexed array of strings.
+   *   Either a string or indexed array of strings.
    *
    * @See Drupal\jwt\JsonWebTokenInterface::getClaim().
    */

--- a/src/PageCache/DisallowJwtAuthRequests.php
+++ b/src/PageCache/DisallowJwtAuthRequests.php
@@ -19,9 +19,11 @@ class DisallowJwtAuthRequests implements RequestPolicyInterface {
    */
   public function check(Request $request) {
     $auth = $request->headers->get('Authorization');
-    if(preg_match('/^Bearer .+/', $auth)) {
+    if (preg_match('/^Bearer .+/', $auth)) {
       return self::DENY;
     }
+
+    return NULL;
   }
 
 }

--- a/src/Transcoder/JwtDecodeException.php
+++ b/src/Transcoder/JwtDecodeException.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Trancoder\JwtDecodeException.
- */
-
 namespace Drupal\jwt\Transcoder;
 
 use Firebase\JWT\SignatureInvalidException;
@@ -26,20 +21,30 @@ class JwtDecodeException extends \Exception {
   const UNKNOWN           = 6;
 
   /**
-   * Contruct a new decode exception from a php-jwt exception.
+   * Construct a new decode exception from a php-jwt exception.
+   *
+   * @param \Exception $e
+   *   The exception to decode.
+   *
+   * @return JwtDecodeException
+   *   The decode exception.
    */
   public static function newFromException(\Exception $e) {
     switch ($e) {
-    case ($e instanceof SignatureInvalidException):
-      return new static($e->getMessage(), self::SIGNATURE_INVALID, $e);
-    case ($e instanceof BeforeValidException):
-      return new static($e->getMessage(), self::BEFORE_VALID, $e);
-    case ($e instanceof ExpiredException):
-      return new static($e->getMessage(), self::EXPIRED, $e);
-    case ($e instanceof \Exception):
-      return new static('Internal Server Error', self::UNKNOWN, $e);
-    default:
-      return new static('Internal Server Error', self::UNKNOWN, $e);
+      case ($e instanceof SignatureInvalidException):
+        return new static($e->getMessage(), self::SIGNATURE_INVALID, $e);
+
+      case ($e instanceof BeforeValidException):
+        return new static($e->getMessage(), self::BEFORE_VALID, $e);
+
+      case ($e instanceof ExpiredException):
+        return new static($e->getMessage(), self::EXPIRED, $e);
+
+      case ($e instanceof \Exception):
+        return new static('Internal Server Error', self::UNKNOWN, $e);
+
+      default:
+        return new static('Internal Server Error', self::UNKNOWN, $e);
     }
   }
 

--- a/src/Transcoder/JwtTranscoder.php
+++ b/src/Transcoder/JwtTranscoder.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Transcoder\JwtTranscoder.
- */
-
 namespace Drupal\jwt\Transcoder;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -29,16 +24,27 @@ class JwtTranscoder implements JwtTranscoderInterface {
 
   /**
    * The allowed algorithms with which a JWT can be decoded.
+   *
+   * @var array
    */
   protected $algorithms = array('HS256');
 
   /**
    * The key used to encode/decode a JsonWebToken.
+   *
+   * @var string
    */
   protected $secret;
 
   /**
-   * Contructs a new JwtTranscoder.
+   * Constructs a new JwtTranscoder.
+   *
+   * @param \Firebase\JWT\JWT $php_jwt
+   *   The JWT library object.
+   * @param ConfigFactoryInterface $configFactory
+   *   Drupal config factory to retrieve the configuration information.
+   * @param KeyRepositoryInterface $key_repo
+   *   The Key repository to retrieve the key.
    */
   public function __construct(JWT $php_jwt, ConfigFactoryInterface $configFactory, KeyRepositoryInterface $key_repo) {
     $this->transcoder = $php_jwt;
@@ -54,26 +60,30 @@ class JwtTranscoder implements JwtTranscoderInterface {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function setSecret($secret) {
     $this->secret = $secret;
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function decode($jwt) {
     try {
       $token = $this->transcoder->decode($jwt, $this->secret, $this->algorithms);
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       throw JwtDecodeException::newFromException($e);
     }
     return new JsonWebToken($token);
   }
 
   /**
-   * Encodes a JsonWebToken.
+   * {@inheritdoc}
    */
-  public function encode(JsonWebTokenInterface $jwt, $options = []) {
+  public function encode(JsonWebTokenInterface $jwt, array $options = []) {
     $options = $this->getOptions($options);
     $encoded = $this->transcoder->encode($jwt->getPayload(), $options['key'], $options['alg']);
     return $encoded;
@@ -81,8 +91,14 @@ class JwtTranscoder implements JwtTranscoderInterface {
 
   /**
    * Gets a standard set of options for encoding a JWT, with overrides.
+   *
+   * @param array $options
+   *   Additional options.
+   *
+   * @return array
+   *   Complete set of options.
    */
-  protected function getOptions($options = array()) {
+  protected function getOptions(array $options = array()) {
     $defaults = array(
       'alg' => 'HS256',
       'key' => $this->secret,

--- a/src/Transcoder/JwtTranscoderInterface.php
+++ b/src/Transcoder/JwtTranscoderInterface.php
@@ -1,11 +1,7 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Transcoder\JwtTranscoderInterface.
- */
-
 namespace Drupal\jwt\Transcoder;
+
 use Drupal\jwt\JsonWebToken\JsonWebTokenInterface;
 
 /**
@@ -18,18 +14,33 @@ interface JwtTranscoderInterface {
   /**
    * Gets a validated JsonWebToken from an encoded JWT.
    *
-   * @returns \Drupal\jwt\JsonWebToken\JsonWebTokenInterface
+   * @param string $jwt
+   *   The encoded JWT.
+   *
+   * @return \Drupal\jwt\JsonWebToken\JsonWebTokenInterface
+   *   Validated JWT.
    */
   public function decode($jwt);
 
   /**
    * Encodes a JsonWebToken.
    *
-   * @param $jwt \Drupal\jwt\JsonWebToken\JsonWebTokenInterface A JWT
-   * @param $options array Options, optional.
+   * @param \Drupal\jwt\JsonWebToken\JsonWebTokenInterface $jwt
+   *   A JWT.
+   * @param array $options
+   *   Options, optional.
    *
-   * @returns string The encoded JWT.
+   * @return string
+   *   The encoded JWT.
    */
-  public function encode(JsonWebTokenInterface $jwt, $options = []);
+  public function encode(JsonWebTokenInterface $jwt, array $options = []);
+
+  /**
+   * Setter for the JWT secret.
+   *
+   * @param string $secret
+   *   The secret for the JWT.
+   */
+  public function setSecret($secret);
 
 }

--- a/src/Validator/JwtInvalidException.php
+++ b/src/Validator/JwtInvalidException.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Validator\JwtInvalidException.
- */
-
 namespace Drupal\jwt\Validator;
 
 /**

--- a/src/Validator/JwtValidator.php
+++ b/src/Validator/JwtValidator.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Validator\JwtValidator.
- */
-
 namespace Drupal\jwt\Validator;
 
 use Drupal\jwt\JsonWebToken\JsonWebTokenInterface;
@@ -36,11 +31,18 @@ class JwtValidator implements JwtValidatorInterface {
 
   /**
    * The current JsonWebToken.
+   *
+   * @var string
    */
   protected $jwt;
 
   /**
    * Constructor.
+   *
+   * @param RequestStack $request_stack
+   *   The request stack.
+   * @param JwtTranscoderInterface $jwt_transcoder
+   *   The JWT transcoder.
    */
   public function __construct(RequestStack $request_stack, JwtTranscoderInterface $jwt_transcoder) {
     $this->requestStack = $request_stack;
@@ -78,8 +80,12 @@ class JwtValidator implements JwtValidatorInterface {
   /**
    * Gets a JsonWebToken from the current request.
    *
+   * @param Request $request
+   *   The request.
+   *
    * @return mixed
-   *  JsonWebToken if on request, false if not.
+   *   JsonWebToken if on request, false if not.
+   *
    * @throws JwtInvalidException
    */
   protected function getJwtFromRequest(Request $request) {

--- a/src/Validator/JwtValidatorInterface.php
+++ b/src/Validator/JwtValidatorInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\jwt\Validator\JwtValidatorInterface.
- */
-
 namespace Drupal\jwt\Validator;
 
 /**
@@ -18,6 +13,7 @@ interface JwtValidatorInterface {
    * Returns a JsonWebToken.
    *
    * @return \Drupal\jwt\JsonWebToken\JsonWebTokenInterface
+   *   The JWT.
    */
   public function getJwt();
 
@@ -29,13 +25,12 @@ interface JwtValidatorInterface {
    * the desired claim value.
    *
    * @param mixed $claim
-   *  The claim to retrieve.
-   *
+   *   The claim to retrieve.
    * @param mixed $grant
-   *  The claim grant to validate.
+   *   The claim grant to validate.
    *
    * @return bool
-   *  Whether the JWT's claim contains the given grant.
+   *   Whether the JWT's claim contains the given grant.
    */
   public function assertClaim($claim, $grant);
 


### PR DESCRIPTION
All files should pass phpcs with coder drupal sniffs now. This is mostly changes to doc comments, but there are a couple places where internal function names are changed to to meet the coding standards.

Sometime it might be a good idea to wire up travisCI to run the sniffs on pull requests. 