### PR TITLE
Add support for additional algorithms 

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\jwt\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\jwt\Transcoder\JwtTranscoder;
 
 /**
  * Class ConfigForm.
@@ -11,6 +15,40 @@ use Drupal\Core\Form\FormStateInterface;
  * @package Drupal\jwt\Form
  */
 class ConfigForm extends ConfigFormBase {
+
+  protected $transcoder;
+  protected $keyRepo;
+
+  /**
+   * ConfigForm constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory for parent.
+   * @param \Drupal\key\KeyRepositoryInterface $key_repo
+   *   Key repo to validate keys.
+   * @param \Drupal\jwt\Transcoder\JwtTranscoder $transcoder
+   *   JWT Transcoder.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    KeyRepositoryInterface $key_repo,
+    JwtTranscoder $transcoder
+  ) {
+    $this->keyRepo = $key_repo;
+    $this->transcoder = $transcoder;
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('key.repository'),
+      $container->get('jwt.transcoder')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -29,13 +67,68 @@ class ConfigForm extends ConfigFormBase {
   }
 
   /**
+   * AJAX Function callback.
+   *
+   * @param array $form
+   *   Drupal form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Drupal formstate object.
+   *
+   * @return mixed
+   *   Updated AJAXed form.
+   */
+  public function ajaxCallback(array &$form, FormStateInterface $form_state) {
+    return $form['key-container'];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['jwt_key'] = [
+    $form['key-container'] = [
+      '#type' => 'container',
+      '#prefix' => '<div id="jwt-key-container">',
+      '#suffix' => '</div>',
+      '#weight' => 10,
+    ];
+
+    $form['jwt_algorithm'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Algorithm'),
+      '#options' => $this->transcoder->getAlgorithmOptions(),
+      '#ajax' => [
+        'callback' => '::ajaxCallback',
+        'event' => 'change',
+        'wrapper' => 'jwt-key-container',
+        'progress' => [
+          'type' => 'throbber',
+        ],
+      ],
+      '#default_value' => $this->config('jwt.config')->get('algorithm'),
+    ];
+
+    if ($form_state->isValueEmpty('jwt_algorithm')) {
+      if (!empty($this->config('jwt.config')->get('algorithm'))) {
+        $type = $this->transcoder->getAlgorithmType($this->config('jwt.config')->get('algorithm'));
+      }
+      else {
+        $type = 'jwt_hs';
+      }
+    }
+    else {
+      $type = $this->transcoder->getAlgorithmType($form_state->getValue('jwt_algorithm'));
+    }
+    $text = ($type == 'jwt_hs') ? $this->t('Secret') : $this->t('Private Key');
+
+    $form['key-container']['jwt_key'] = [
       '#type' => 'key_select',
-      '#title' => $this->t('JWT Secret'),
+      '#title' => $text,
       '#default_value' => $this->config('jwt.config')->get('key_id'),
+      '#key_filters' => [
+        'type' => $type,
+      ],
+      '#validated' => TRUE,
+      '#required' => TRUE,
     ];
 
     return parent::buildForm($form, $form_state);
@@ -45,6 +138,18 @@ class ConfigForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
+    $algorithm = $form_state->getValue('jwt_algorithm');
+    $key_id = $form_state->getValue('jwt_key');
+    $key = $this->keyRepo->getKey($key_id);
+
+    if ($key != NULL && $key->getKeyType()->getPluginId() != $this->transcoder->getAlgorithmType($algorithm)) {
+      $form_state->setErrorByName('jwt_key', $this->t('Incorrect key type selected.'));
+    }
+
+    if ($key != NULL && $key->getKeyType()->getConfiguration()['algorithm'] != $algorithm) {
+      $form_state->setErrorByName('jwt_key', $this->t('Key does not match algorithm selected.'));
+    }
+
     parent::validateForm($form, $form_state);
   }
 
@@ -55,6 +160,10 @@ class ConfigForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     $values = $form_state->getValues();
+
+    if (isset($values['jwt_algorithm'])) {
+      $this->config('jwt.config')->set('algorithm', $values['jwt_algorithm'])->save();
+    }
 
     if (isset($values['jwt_key'])) {
       $this->config('jwt.config')->set('key_id', $values['jwt_key'])->save();

--- a/src/Plugin/KeyType/JwtHsKeyType.php
+++ b/src/Plugin/KeyType/JwtHsKeyType.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\jwt\Plugin\KeyType;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\Crypt;
+use Drupal\key\Plugin\KeyTypeBase;
+use Drupal\key\Plugin\KeyPluginFormInterface;
+
+/**
+ * Defines a key type for JWT HMAC Signatures.
+ *
+ * @KeyType(
+ *   id = "jwt_hs",
+ *   label = @Translation("JWT HMAC Key"),
+ *   description = @Translation("A key used for JWT HMAC algorithms."),
+ *   group = "encryption",
+ *   key_value = {
+ *     "plugin" = "text_field"
+ *   }
+ * )
+ */
+class JwtHsKeyType extends KeyTypeBase implements KeyPluginFormInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'algorithm' => 'HS256',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $algorithm_options = [
+      'HS256' => $this->t('HMAC using SHA-256 (HS256)'),
+      'HS384' => $this->t('HMAC using SHA-384 (HS384)'),
+      'HS512' => $this->t('HMAC using SHA-512 (HS512)'),
+    ];
+
+    $algorithm = $this->getConfiguration()['algorithm'];
+
+    $form['algorithm'] = array(
+      '#type' => 'select',
+      '#title' => $this->t('JWT Algorithm'),
+      '#description' => $this->t('The JWT Algorithm to use with this key.'),
+      '#options' => $algorithm_options,
+      '#default_value' => $algorithm,
+      '#required' => TRUE,
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration($form_state->getValues());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateKeyValue(array $configuration) {
+    $algorithm_keysize = self::getAlgorithmKeysize();
+
+    $algorithm = $configuration['algorithm'];
+
+    if (!empty($algorithm) && isset($algorithm_keysize[$algorithm])) {
+      $bytes = $algorithm_keysize[$algorithm] / 8;
+    }
+    else {
+      $bytes = $algorithm_keysize['HS256'] / 8;
+    }
+    $random_key = Crypt::randomBytes($bytes);
+
+    return $random_key;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateKeyValue(array $form, FormStateInterface $form_state, $key_value) {
+    if (!$form_state->getValue('algorithm')) {
+      return;
+    }
+
+    // Validate the key size.
+    $algorithm = $form_state->getValue('algorithm');
+    $bytes = self::getAlgorithmKeysize()[$algorithm] / 8;
+    if (strlen($key_value) < $bytes) {
+      $form_state->setErrorByName('algorithm', $this->t('Key size (%size bits) is too small for algorithm chosen. Algorithm requires a minimum of %required bits.', ['%size' => strlen($key_value) * 8, '%required' => $bytes * 8]));
+    }
+  }
+
+  /**
+   * Get keysizes for the various algorithms.
+   *
+   * @return array
+   *   An array key keysizes.
+   */
+  protected static function getAlgorithmKeysize() {
+    return [
+      'HS256' => 512,
+      'HS384' => 1024,
+      'HS512' => 1024,
+    ];
+  }
+
+}

--- a/src/Plugin/KeyType/JwtRsKeyType.php
+++ b/src/Plugin/KeyType/JwtRsKeyType.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\jwt\Plugin\KeyType;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\key\Plugin\KeyTypeBase;
+use Drupal\key\Plugin\KeyPluginFormInterface;
+
+/**
+ * Defines a key type for JWT RSA Signatures.
+ *
+ * @KeyType(
+ *   id = "jwt_rs",
+ *   label = @Translation("JWT RSA Key"),
+ *   description = @Translation("A key type used for JWT RSA signature algorithms."),
+ *   group = "privatekey",
+ *   key_value = {
+ *     "plugin" = "textarea_field"
+ *   }
+ * )
+ */
+class JwtRsKeyType extends KeyTypeBase implements KeyPluginFormInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'algorithm' => 'RS256',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $algorithm_options = [
+      'RS256' => $this->t('RSASSA-PKCS1-v1_5 using SHA-256 (RS256)'),
+    ];
+
+    $algorithm = $this->getConfiguration()['algorithm'];
+
+    $form['algorithm'] = array(
+      '#type' => 'select',
+      '#title' => $this->t('JWT Algorithm'),
+      '#description' => $this->t('The JWT Algorithm to use with this key.'),
+      '#options' => $algorithm_options,
+      '#default_value' => $algorithm,
+      '#required' => TRUE,
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration($form_state->getValues());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateKeyValue(array $configuration) {
+    $algorithm_keysize = self::getAlgorithmKeysize();
+    $algorithm = $configuration['algorithm'];
+
+    if (empty($algorithm) || !isset($algorithm_keysize[$algorithm])) {
+      $algorithm = 'RS256';
+    }
+
+    $key_resource = openssl_pkey_new([
+      'private_key_bits' => $algorithm_keysize[$algorithm],
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+
+    $key_string = '';
+
+    openssl_pkey_export($key_resource, $key_string);
+    openssl_pkey_free($key_resource);
+
+    return $key_string;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateKeyValue(array $form, FormStateInterface $form_state, $key_value) {
+    if (!$form_state->getValue('algorithm')) {
+      return;
+    }
+
+    // Validate the key.
+    $algorithm = $form_state->getValue('algorithm');
+
+    $key_resource = openssl_pkey_get_private($key_value);
+    if ($key_resource === FALSE) {
+      $form_state->setErrorByName('algorithm', $this->t('Invalid Private Key.'));
+    }
+
+    $key_details = openssl_pkey_get_details($key_resource);
+    if ($key_details === FALSE) {
+      $form_state->setErrorByName('algorithm', $this->t('Unable to get private key details.'));
+    }
+
+    $required_bits = self::getAlgorithmKeysize()[$algorithm];
+    if ($key_details['bits'] < $required_bits) {
+      $form_state->setErrorByName('algorithm', $this->t('Key size (%size bits) is too small for algorithm chosen. Algorithm requires a minimum of %required bits.', ['%size' => $key_details['bits'], '%required' => $required_bits]));
+    }
+
+    if ($key_details['type'] != OPENSSL_KEYTYPE_RSA) {
+      $form_state->setErrorByName('algorithm', $this->t('Key must be RSA.'));
+    }
+
+    openssl_pkey_free($key_resource);
+  }
+
+  /**
+   * Get keysizes for the various algorithms.
+   *
+   * @return array
+   *   An array key keysizes.
+   */
+  protected static function getAlgorithmKeysize() {
+    return [
+      'RS256' => 2048,
+    ];
+  }
+
+}

--- a/src/Transcoder/JwtTranscoder.php
+++ b/src/Transcoder/JwtTranscoder.php
@@ -25,16 +25,67 @@ class JwtTranscoder implements JwtTranscoderInterface {
   /**
    * The allowed algorithms with which a JWT can be decoded.
    *
-   * @var array
+   * @var string
    */
-  protected $algorithms = array('HS256');
+  protected $algorithm;
+
+  /**
+   * The algorithm type we are using.
+   *
+   * @var string
+   */
+  protected $algorithmType;
 
   /**
    * The key used to encode/decode a JsonWebToken.
    *
    * @var string
    */
-  protected $secret;
+  protected $secret = NULL;
+
+  /**
+   * The PEM encoded private key used for signing RSA JWTs.
+   *
+   * @var string
+   */
+  protected $privateKey = NULL;
+
+  /**
+   * The PEM encoded public key used to verify signatures on RSA JWTs.
+   *
+   * @var string
+   */
+  protected $publicKey = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getAlgorithmOptions() {
+    return [
+      'HS256' => 'HMAC using SHA-256 (HS256)',
+      'HS384' => 'HMAC using SHA-384 (HS384)',
+      'HS512' => 'HMAC using SHA-512 (HS512)',
+      'RS256' => 'RSASSA-PKCS1-v1_5 using SHA-256 (RS256)',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getAlgorithmType($algorithm) {
+    switch ($algorithm) {
+      case 'HS256':
+      case 'HS384':
+      case 'HS512':
+        return 'jwt_hs';
+
+      case 'RS256':
+        return 'jwt_rs';
+
+      default:
+        return NULL;
+    }
+  }
 
   /**
    * Constructs a new JwtTranscoder.
@@ -48,14 +99,21 @@ class JwtTranscoder implements JwtTranscoderInterface {
    */
   public function __construct(JWT $php_jwt, ConfigFactoryInterface $configFactory, KeyRepositoryInterface $key_repo) {
     $this->transcoder = $php_jwt;
-
     $key_id = $configFactory->get('jwt.config')->get('key_id');
+    $this->setAlgorithm($configFactory->get('jwt.config')->get('algorithm'));
+
     if (isset($key_id)) {
       $key = $key_repo->getKey($key_id);
-
       if (!is_null($key)) {
-        $secret = $key->getKeyValue();
-        $this->setSecret($secret);
+        $key_value = $key->getKeyValue();
+        if ($this->algorithmType == 'jwt_hs') {
+          // Symmetric algorithm so we set the secret.
+          $this->setSecret($key_value);
+        }
+        elseif ($this->algorithmType == 'jwt_rs') {
+          // Asymmetric algorithm so we set the private key.
+          $this->setPrivateKey($key_value);
+        }
       }
     }
   }
@@ -70,9 +128,51 @@ class JwtTranscoder implements JwtTranscoderInterface {
   /**
    * {@inheritdoc}
    */
+  public function setAlgorithm($algorithm) {
+    $this->algorithm = $algorithm;
+    $this->algorithmType = $this->getAlgorithmType($algorithm);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setPrivateKey($private_key, $derive_public_key = TRUE) {
+    $key_context = openssl_pkey_get_private($private_key);
+    $key_details = openssl_pkey_get_details($key_context);
+    if ($key_details === FALSE || $key_details['type'] != OPENSSL_KEYTYPE_RSA) {
+      return FALSE;
+    }
+
+    $this->privateKey = $private_key;
+    if ($derive_public_key) {
+      $this->publicKey = $key_details['key'];
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setPublicKey($public_key) {
+    $key_context = openssl_pkey_get_public($public_key);
+    $key_details = openssl_pkey_get_details($key_context);
+    if ($key_details === FALSE || $key_details['type'] != OPENSSL_KEYTYPE_RSA) {
+      return FALSE;
+    }
+
+    $this->publicKey = $public_key;
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function decode($jwt) {
+    $key = $this->getKey('decode');
+    $algorithms = [$this->algorithm];
     try {
-      $token = $this->transcoder->decode($jwt, $this->secret, $this->algorithms);
+      $token = $this->transcoder->decode($jwt, $key, $algorithms);
     }
     catch (\Exception $e) {
       throw JwtDecodeException::newFromException($e);
@@ -83,28 +183,38 @@ class JwtTranscoder implements JwtTranscoderInterface {
   /**
    * {@inheritdoc}
    */
-  public function encode(JsonWebTokenInterface $jwt, array $options = []) {
-    $options = $this->getOptions($options);
-    $encoded = $this->transcoder->encode($jwt->getPayload(), $options['key'], $options['alg']);
+  public function encode(JsonWebTokenInterface $jwt) {
+    $key = $this->getKey('encode');
+    // Refuse to encode if we don't have a key yet.
+    if ($key === NULL) {
+      return FALSE;
+    }
+    $encoded = $this->transcoder->encode($jwt->getPayload(), $key, $this->algorithm);
     return $encoded;
   }
 
   /**
-   * Gets a standard set of options for encoding a JWT, with overrides.
+   * Helper function to get the correct key based on operation.
    *
-   * @param array $options
-   *   Additional options.
+   * @param string $operation
+   *   The operation being performed. One of: encode, decode.
    *
-   * @return array
-   *   Complete set of options.
+   * @return null|string
+   *   Returns NULL if opteration is not found. Otherwise returns key.
    */
-  protected function getOptions(array $options = array()) {
-    $defaults = array(
-      'alg' => 'HS256',
-      'key' => $this->secret,
-    );
-
-    return array_merge_recursive($options, $defaults);
+  protected function getKey($operation) {
+    if ($this->algorithmType == 'jwt_hs') {
+      return $this->secret;
+    }
+    elseif ($this->algorithmType == 'jwt_rs') {
+      if ($operation == 'encode') {
+        return $this->privateKey;
+      }
+      elseif ($operation == 'decode') {
+        return $this->publicKey;
+      }
+    }
+    return NULL;
   }
 
 }

--- a/src/Transcoder/JwtTranscoderInterface.php
+++ b/src/Transcoder/JwtTranscoderInterface.php
@@ -27,20 +27,87 @@ interface JwtTranscoderInterface {
    *
    * @param \Drupal\jwt\JsonWebToken\JsonWebTokenInterface $jwt
    *   A JWT.
-   * @param array $options
-   *   Options, optional.
    *
    * @return string
    *   The encoded JWT.
    */
-  public function encode(JsonWebTokenInterface $jwt, array $options = []);
+  public function encode(JsonWebTokenInterface $jwt);
 
   /**
-   * Setter for the JWT secret.
+   * Sets the secret that is used for a symmetric algorithm signature.
+   *
+   * The secret is only used when a symmetric algorithm is selected. Currently
+   * the symmetric algorithms supported are:
+   *   * HS256
+   *   * HS384
+   *   * HS512
+   * The secret is used for both signature creation and verification.
    *
    * @param string $secret
    *   The secret for the JWT.
    */
   public function setSecret($secret);
+
+  /**
+   * Sets the algorithm to be used for the JWT.
+   *
+   * @param string $algorithm
+   *   This can be any of the array keys returned by the getAlgorithmOptions
+   *   function.
+   *
+   * @see getAlgorithmOptions()
+   */
+  public function setAlgorithm($algorithm);
+
+  /**
+   * Sets the private key used to create signatures for an asymmetric algorithm.
+   *
+   * This key is only used when an asymmetric algorithm is selected. Currently
+   * supported asymmetric algorithms are:
+   *   * RS256
+   *
+   * @param string $private_key
+   *   A PEM encoded private key.
+   * @param bool $derive_public_key
+   *   (Optional) Derive the public key from the private key. Defaults to true.
+   *
+   * @return bool
+   *   Function does some validation of the key. Returns TRUE on success.
+   */
+  public function setPrivateKey($private_key, $derive_public_key = TRUE);
+
+  /**
+   * Sets the public key used to verify signatures for an asymmetric algorithm.
+   *
+   * This key is only used when an asymmetric algorithm is selected. Currently
+   * supported asymmetric algorithms are:
+   *   * RS256
+   *
+   * @param string $public_key
+   *   A PEM encoded public key.
+   *
+   * @return mixed
+   *   Function does some validation of the key. Returns TRUE on success.
+   */
+  public function setPublicKey($public_key);
+
+  /**
+   * Return the type of algorithm selected.
+   *
+   * @param string $algorithm
+   *   The algorithm.
+   *
+   * @return string
+   *   The algorithm type. Returns NULL if algorithm not found.
+   */
+  public static function getAlgorithmType($algorithm);
+
+  /**
+   * Gets a list of algorithms supported by this transcoder.
+   *
+   * @return array
+   *   An array of options formatted for a select list.
+   */
+  public static function getAlgorithmOptions();
 
 }


### PR DESCRIPTION
JWT module now supports all the algorithms supported by the underlying
firebase JWT library. This includes the asymetric RSA algorithm RSA256.
The algorithm is set in the configruation page.

In order to support both asymmetric and symmetric algorithms, a couple
new key types have been defined for the key module. This lets us use PEM
encoded private keys for RSA encryption.

This pull contains the commits submitted in #5 and #6. I can reroll this pull if it needs, once those pull requests land. Just wanted to get it submitted.