### PR TITLE
Update provider_id in authentication service definition

### DIFF
--- a/jwt.services.yml
+++ b/jwt.services.yml
@@ -3,7 +3,7 @@ services:
     class: Drupal\jwt\Authentication\Provider\JwtAuth
     arguments: [ '@entity_type.manager', '@jwt.transcoder', '@event_dispatcher' ]
     tags:
-      - { name: authentication_provider, provider_id: 'jwt_auth', global: TRUE, priority: 100 }
+      - { name: authentication_provider, provider_id: 'jwt', global: TRUE, priority: 100 }
   jwt.page_cache_request_policy.disallow_jwt_auth_requests:
       class: Drupal\jwt\PageCache\DisallowJwtAuthRequests
       public: false


### PR DESCRIPTION
Must match module name, else `RestExport::calculateDependencies()` et. al. in rest module can't properly add jwt module as a config dependency, e.g., when saving a view.