### PR TITLE
Handling DomainException

### DIFF
--- a/src/Transcoder/JwtDecodeException.php
+++ b/src/Transcoder/JwtDecodeException.php
@@ -39,6 +39,9 @@ class JwtDecodeException extends \Exception {
 
       case ($e instanceof ExpiredException):
         return new static($e->getMessage(), self::EXPIRED, $e);
+        
+      case ($e instanceof \DomainException):
+        return new static($e->getMessage(), self::DOMAIN, $e);  
 
       case ($e instanceof \Exception):
         return new static('Internal Server Error', self::UNKNOWN, $e);


### PR DESCRIPTION
When the token has been fiddled with, the error is caught and passed on as a general exception with "Internal Server Error" message. Catching the error as DomainException and passing on the original error message seems more useful to me.